### PR TITLE
Adding docs on JS cell rendering

### DIFF
--- a/docs/JavascriptRendering.rst
+++ b/docs/JavascriptRendering.rst
@@ -2,8 +2,6 @@
 JavaScript used by IPython for rendering cells
 ===========================================================
 
-.. sectnum::
-
 .. contents:: Javascript files
 
 notebook.js


### PR DESCRIPTION
Document with JavaScript rendering code used by IPython for rendering cells. See #11 .
