### PR TITLE
Add entry_points to python package.

### DIFF
--- a/nbdiff/__init__.py
+++ b/nbdiff/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__author__ = 'Tavish Armstrong'
+__author__ = 'The NBDiff Team'
 __email__ = 'tavisharmstrong@gmail.com'
-__version__ = '0.1.0'
+__version__ = '0.0.0'

--- a/nbdiff/commands.py
+++ b/nbdiff/commands.py
@@ -1,0 +1,22 @@
+'''
+Entry points for the nbdiff package.
+'''
+import argparse
+
+def diff():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('notebook', nargs='*')
+    args = parser.parse_args()
+    # TODO take 0 or 2 arguments
+    # if 0, use version control (unstaged changes)
+    # if 2, use the files.
+    print ('Arguments received: {}'.format(args))
+
+def merge():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('notebook', nargs='*')
+    args = parser.parse_args()
+    # TODO take 0 or 3 arguments.
+    # if 0, use version control
+    # if 3, use the files.
+    print ('Arguments received: {}'.format(args))

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'nbdiff',
     ],
     package_dir={'nbdiff': 'nbdiff'},
+    entry_points={'console_scripts': ['nbdiff = nbdiff.commands:diff', 'nbmerge = nbdiff.commands:merge']},
     include_package_data=True,
     install_requires=[
     ],


### PR DESCRIPTION
This creates the commands `nbdiff` and `nbmerge` that a user would be able to run after installing the nbdiff package.
