### PR TITLE
Remove json checks from travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ script:
   - python setup.py nosetests
   - flake8 nbdiff
   - flake8 tests
-  - python -m json.tool specs/test_cases_simple.json
-  - python -m json.tool specs/test_cases_cells.json
 
 notifications:
   email:


### PR DESCRIPTION
We added these checks a while ago but they're unnecessary and just add a bunch of output to every build that we don't care about.
