### PR TITLE
Add install_requires to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setup(
     ]},
     include_package_data=True,
     install_requires=[
+        'flask',
+        'jinja2',
+        'ipython',
     ],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
So people don't have to run pip install -r requirements any more.
