### PR TITLE
Remove nbdiff-type from notebook metadata on merge save.

### DIFF
--- a/nbdiff/server/static/nbdiff.js
+++ b/nbdiff/server/static/nbdiff.js
@@ -126,9 +126,9 @@ NBDiff.prototype = {
             if (nbcell.state() === 'added' || nbcell.state() === 'unchanged') {
                 nbcell.removeMetadata();
             }
-            else {
-            }
         });
+
+        delete IPython.notebook.metadata['nbdiff-type'];
 
         IPython.notebook.save_notebook();
     },


### PR DESCRIPTION
Fixes #144.
