### PR TITLE
Support nbdiff --check in file mode

### DIFF
--- a/nbdiff/commands.py
+++ b/nbdiff/commands.py
@@ -68,8 +68,9 @@ def diff():
             result = notebook_diff(notebook1, notebook2)
 
             app.add_notebook(result, 'no_filename')
-            open_browser(args.browser)
-            app.run(debug=False)
+            if not args.check:
+                open_browser(args.browser)
+                app.run(debug=False)
 
         else:
             print('The notebooks could not be diffed.')


### PR DESCRIPTION
If we run `nbdiff --check f1.ipynb f2.ipynb`, it launches the browser. This is obviously confusing and bad for test scripts.
